### PR TITLE
Modified FacebookPublishing Plugin to upload exposure date information a...

### DIFF
--- a/plugins/shotwell-publishing/FacebookPublishing.vala
+++ b/plugins/shotwell-publishing/FacebookPublishing.vala
@@ -1398,7 +1398,9 @@ internal class GraphSession {
                 mp_envelope.append_form_string("name", publishable_title);
                 
             //Set 'message' data field with EXIF comment field
-            mp_envelope.append_form_string("message", publishable.get_param_string("comment"));
+            string publishable_comment = publishable.get_param_string("comment");
+            if (publishable_comment != null)
+               mp_envelope.append_form_string("message", publishable_comment);
             
             //Sets correct date of the picture
             mp_envelope.append_form_string("backdated_time", publishable.get_exposure_date_time().to_string());


### PR DESCRIPTION
Hi,

I have made some minor modifications on the Facebook Publishing Plugin:
1. A field 'message' (check GraphApi reference) is included in the request containing the EXIV parameters 'comment'. This publishes the image comment on the Facebook image description.
2. A field 'backdated_time' is also included with the exposure time obtained from the publishable object. This sets the image date to the exposure date on the Facebook Timeline.
   I applied these changes (check the patch file attached) to the latest git commit (b1fb4bd09), compiled the code and tested it. It works as expected.

I hope you can merge them and make this feature available in the next release. It is going to be a great advantage to have Shotwell doing a decent Facebook export, given that this is hard to find, specially in an open source image gallery.
