### PR TITLE
Changed Czech translation of To: to "Do:"

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -2859,7 +2859,7 @@ msgstr "Od:"
 
 #: ../src/Properties.vala:385 ../src/Properties.vala:390
 msgid "To:"
-msgstr "Pro:"
+msgstr "Do:"
 
 #: ../src/Properties.vala:395 ../src/editing_tools/EditingTools.vala:1872
 msgid "Size:"


### PR DESCRIPTION
Thre translation of "To:" was "Pro:", which is wrong. Should be "Do:"
