### PR TITLE
added scrubbing functionality to directory items

### DIFF
--- a/src/CheckerboardLayout.vala
+++ b/src/CheckerboardLayout.vala
@@ -340,6 +340,10 @@ public abstract class CheckerboardItem : ThumbnailView {
         return is_cursor;
     }
     
+    public virtual void handle_mouse_motion(int x, int y, int height, int width) {
+
+    }
+
     protected override void notify_membership_changed(DataCollection? collection) {
         bool title_visible = (bool) get_collection_property(PROP_SHOW_TITLES, true);
         bool comment_visible = (bool) get_collection_property(PROP_SHOW_COMMENTS, true);
@@ -1277,6 +1281,11 @@ public class CheckerboardLayout : Gtk.DrawingArea {
     }
 
     public bool handle_mouse_motion(CheckerboardItem item, int x, int y, Gdk.ModifierType mask) {
+        int dx = x - item.allocation.x;
+        int dy = y - item.allocation.y;
+
+        item.handle_mouse_motion(dx, dy, item.allocation.height, item.allocation.width);
+
         if (!item.has_tags || is_drag_select_active())
             return false;
         int tag_index = internal_handle_tag_mouse_event(item, x, y);

--- a/src/events/EventDirectoryItem.vala
+++ b/src/events/EventDirectoryItem.vala
@@ -146,6 +146,10 @@ class EventDirectoryItem : CheckerboardItem {
     protected override void thumbnail_altered() {
         MediaSource media = event.get_primary_source();
         
+        set_paul_lynde(media);
+    }
+
+    private void set_paul_lynde(MediaSource media) {
         // get new center square
         paul_lynde = get_paul_lynde_rect(media);
         
@@ -158,11 +162,18 @@ class EventDirectoryItem : CheckerboardItem {
         } else {
             clear_image(Dimensions.for_rectangle(paul_lynde));
         }
-        
+
         base.thumbnail_altered();
     }
 
-    protected override void paint_shadow(Cairo.Context ctx, Dimensions dimensions, Gdk.Point origin, 
+    public override void handle_mouse_motion(int x, int y, int height, int width) {
+        int element_index = (int) Math.round( (double) x / width * (event.get_media_count() - 1) );
+        unowned MediaSource media = event.get_media().to_array()[element_index];
+
+        set_paul_lynde(media);
+    }
+
+    protected override void paint_shadow(Cairo.Context ctx, Dimensions dimensions, Gdk.Point origin,
         int radius, float initial_alpha) {       
         Dimensions altered = Dimensions(dimensions.width - 25, dimensions.height - 25);
         base.paint_shadow(ctx, altered, origin, 36, initial_alpha);


### PR DESCRIPTION
This changes the behaviour of EventItems when the user moves the mouse over them, scrolling through the images contained.
It should look like this: [example](https://user-images.githubusercontent.com/725406/36646486-2d51aabe-1a78-11e8-8245-aa4d412e60db.gif).

I am not sure, if all the necessary places have been updated and if adding the method `handle_mouse_motion` is fine, If not I would appreciate feedback.

Todos for me (if there even is interest in merging):
- [ ] switch back to the primary_image if the mouse leaves an EventItem
- [ ] comments for code