### PR TITLE
Use the largest dimension when chosing the thumbnail size

### DIFF
--- a/src/ThumbnailCache.vala
+++ b/src/ThumbnailCache.vala
@@ -149,7 +149,7 @@ public class ThumbnailCache : Object {
         private void generate_thumbnail() throws Error {
             Photo? photo = source as Photo;
             if (photo != null) {
-                unscaled = photo.get_pixbuf(Scaling.for_best_fit(dim.width, true));
+                unscaled = photo.get_pixbuf(Scaling.for_best_fit(dim.major_axis(), true));
             } else {
                 Video? video = source as Video;
                 if (video != null)


### PR DESCRIPTION
If you just use the width, portrait oriented photos have blurry thumbnails. This changes the thumbnail generation code to use the largest dimension.

Before and after screenshots:

![before](https://user-images.githubusercontent.com/251659/44313556-7e6db480-a3bf-11e8-9b7b-a02927eff5e9.png)
![after](https://user-images.githubusercontent.com/251659/44313558-8168a500-a3bf-11e8-8bd6-ee80b83b74a2.png)

